### PR TITLE
Overview

### DIFF
--- a/inst/extdata/split_slides.lua
+++ b/inst/extdata/split_slides.lua
@@ -2,8 +2,27 @@ function Pandoc(doc)
     local slides = pandoc.List({
         -- We add each of the episode titles as a title slide
         pandoc.Header(1, doc.meta.title),
-        pandoc.HorizontalRule()
     })
+
+    -- Add the questions and objectives to the title slide
+    doc:walk({
+        Div = function(div)
+            if div.classes:includes("questions") then
+                div.classes = {"overview"}
+                div.content:insert(1, pandoc.Header(2, "Questions"))
+                table.insert(slides, div)
+                return div
+            elseif div.classes:includes("objectives") then
+                div.classes = {"overview"}
+                div.content:insert(1, pandoc.Header(2, "Objectives"))
+                table.insert(slides, div)
+                return div
+            end
+        end
+    })
+
+    -- Close the title slide
+    table.insert(slides, pandoc.HorizontalRule())
 
     -- Only keep certain elements: figures and challenges
     doc:walk({


### PR DESCRIPTION
Closes #7.

Looks like:

![Screen Shot 2024-07-10 at 6 09 26 pm](https://github.com/WEHI-ResearchComputing/CarpentriesSlides/assets/5019367/91766277-ff5c-46f6-b9a0-9a302c8adefa)

Although it would have been nice to use the Carpentries overview styling, the lua filter in sandpaper has some dodgy code that uses global variables. When it encounters the slide show with multiple sets of objectives, it duplicates everything:
![Screen Shot 2024-07-10 at 6 21 16 pm](https://github.com/WEHI-ResearchComputing/CarpentriesSlides/assets/5019367/3d54f4b1-f9ee-4968-996b-436c76859a93)

